### PR TITLE
Update checkLdapPwdExpiration.sh

### DIFF
--- a/checkLdapPwdExpiration.sh
+++ b/checkLdapPwdExpiration.sh
@@ -236,7 +236,7 @@ fi
 ## Performs global search
 ${MY_LDAP_SEARCHBIN} ${ldap_param} -s ${MY_LDAP_SEARCHSCOPE} \
 	-b "${MY_LDAP_SEARCHBASE}" "${MY_LDAP_SEARCHFILTER}" \
-	"dn" > ${result_file}
+	"dn" | grep -iE '^dn:' > ${result_file}
 
 ## Loops on results
 while read dnStr


### PR DESCRIPTION
openLdap could restrict the number of entries that a client can retrieve in a single operation to 500 and then it print some lines with  '# pagedresults: cookie= ' each 500 entries.
So grep only the goods ones.