### PR TITLE
force mktime to work with UTC like in OpenLdap

### DIFF
--- a/checkLdapPwdExpiration.sh
+++ b/checkLdapPwdExpiration.sh
@@ -204,7 +204,7 @@ getTimeInSeconds() {
 	os=`uname -s`
 
 	if [ "$1" ]; then
-		date=`${MY_GAWK_BIN} 'BEGIN  { \
+		date=`TZ=UTC ${MY_GAWK_BIN} 'BEGIN  { \
 			if (ARGC == 2) { \
 		        	print mktime(ARGV[1]) \
 			} \


### PR DESCRIPTION
I use OpenLdap and date are in UTC (20201122112233Z).
In getTimeInSeconds, mktime use current locale (in man: "expressed as local time") so:
pwdChangedTime=getTimeInSeconds "$y $M $d $h $m $s"
is the number of seconds for "my date changed in UTC" (for me, my date less 1H) and not my UTC date.
And so when I print it in the mail with expireTimeTZ it's false